### PR TITLE
Set ApplePay status after getting ApplePay results from Payfort SDK

### DIFF
--- a/ios/Classes/PayfortDelegate.swift
+++ b/ios/Classes/PayfortDelegate.swift
@@ -172,24 +172,24 @@ public class PayFortDelegate: NSObject, PKPaymentAuthorizationViewControllerDele
                 success: { requestDic, responeDic in
                     
                     print("succeeded: - \(requestDic) - \(responeDic)")
+                    completion(.success)
                     self.channel?.invokeMethod("apple_pay_succeeded", arguments: responeDic)
-                    controller.dismiss(animated: true)
                     return
                     
                 },
                 faild: { requestDic, responeDic, message in
                     
                     print("failed: \(message) - \(requestDic) - \(responeDic)")
+                    completion(.failure)
                     self.channel?.invokeMethod("apple_pay_failed", arguments: ["message": message])
-                    controller.dismiss(animated: true)
                     return
                     
                 })
         } else {
             
             print("asyncSuccessful: \(asyncSuccessful)")
+            completion(.failure)
             self.channel?.invokeMethod("apple_pay_failed", arguments: ["message": "Something went wrong"])
-            controller.dismiss(animated: true)
         }
         
     }


### PR DESCRIPTION
- Set ApplePay status after getting ApplePay results from Payfort SDK.
- Remove `controller.dismiss` from callbacks because it's already implemented in the `paymentAuthorizationViewControllerDidFinish` abstraction function.


- Before:

https://github.com/vvvirani/flutter_amazon_payfort/assets/32925513/c427b66b-849c-4c87-a0ce-76179f265ca0


- After: 

https://github.com/vvvirani/flutter_amazon_payfort/assets/32925513/ff883087-1e74-41ac-b1c9-923e8e06b80d



