### PR TITLE
Add Command Enum for Customizable Command Types

### DIFF
--- a/android/src/main/kotlin/com/vvvirani/amazon_payfort/AmazonPayfortPlugin.kt
+++ b/android/src/main/kotlin/com/vvvirani/amazon_payfort/AmazonPayfortPlugin.kt
@@ -82,7 +82,7 @@ class AmazonPayfortPlugin : FlutterPlugin,
 
     private fun createRequestMap(call: MethodCall): MutableMap<String, Any?> {
         val requestMap: MutableMap<String, Any?> = HashMap()
-        requestMap["command"] = "PURCHASE"
+        requestMap["command"] = call.argument<String>("command")
         requestMap["customer_name"] = call.argument<String>("customer_name")
         requestMap["customer_email"] = call.argument<String>("customer_email")
         requestMap["currency"] = call.argument<String>("currency")

--- a/example/lib/providers/payment_provider.dart
+++ b/example/lib/providers/payment_provider.dart
@@ -35,6 +35,7 @@ class PaymentProvider extends DefaultChangeNotifier {
       /// Step 4: Processing Payment [Amount multiply with 100] ex. 10 * 100 = 1000 (10 SAR)
       /// Amount value send always round ex. [100] not [100.00, 100.21]
       FortRequest request = FortRequest(
+        command: Command.authorization,
         amount: 10 * 100,
         customerName: 'Test Customer',
         customerEmail: 'test@customer.com',
@@ -75,6 +76,7 @@ class PaymentProvider extends DefaultChangeNotifier {
       /// Step 4: Processing Payment [Don't multiply with 100]
       /// Amount value send always round ex. [100] not [100.00, 100.21]
       FortRequest request = FortRequest(
+        command: Command.purchase,
         amount: 1000,
         customerName: 'Test Customer',
         customerEmail: 'test@customer.com',

--- a/ios/Classes/PayfortDelegate.swift
+++ b/ios/Classes/PayfortDelegate.swift
@@ -47,7 +47,7 @@ public class PayFortDelegate: NSObject, PKPaymentAuthorizationViewControllerDele
     
     public func callPayFort(requestData : Dictionary<String, Any>, viewController : UIViewController){
         var request = [String : String]()
-        request["command"] = "PURCHASE";
+        request["command"] = (requestData["command"] as? String) ?? "";
         request["customer_name"] = (requestData["customer_name"] as? String) ?? "";
         request["customer_email"] = (requestData["customer_email"] as? String) ?? "";
         request["currency"] = (requestData["currency"] as? String) ?? "";
@@ -140,7 +140,7 @@ public class PayFortDelegate: NSObject, PKPaymentAuthorizationViewControllerDele
         if asyncSuccessful {
             var request = [String : String]()
             request["digital_wallet"] = "APPLE_PAY"
-            request["command"] = "PURCHASE";
+            request["command"] = (requestData?["command"] as? String) ?? "";
             request["amount"] = String(amount.toInt() ?? 0);
             request["currency"] = (requestData?["currency"] as? String) ?? "";
             request["language"] = (requestData?["language"] as? String) ?? "";

--- a/lib/amazon_payfort.dart
+++ b/lib/amazon_payfort.dart
@@ -4,12 +4,11 @@ import 'package:amazon_payfort/src/helpers/exceptions.dart';
 import 'package:amazon_payfort/src/models/fort_request.dart';
 import 'package:amazon_payfort/src/models/pay_fort_options.dart';
 
+export 'src/enums/command.dart';
 export 'src/enums/fort_environment.dart';
-
-export 'src/models/models.dart';
-
 export 'src/helpers/call_backs.dart';
 export 'src/helpers/exceptions.dart';
+export 'src/models/models.dart';
 
 /// Amazon Payment Services is the new name for PayFort.
 /// PayFort is a leading provider of payment processing services that was acquired by Amazon in 2017.

--- a/lib/src/enums/command.dart
+++ b/lib/src/enums/command.dart
@@ -1,0 +1,6 @@
+enum Command {
+  authorization,
+  purchase;
+
+  String get toUpperCaseString => name.toUpperCase();
+}

--- a/lib/src/models/fort_request.dart
+++ b/lib/src/models/fort_request.dart
@@ -1,4 +1,8 @@
+import 'package:amazon_payfort/src/enums/command.dart';
+
 class FortRequest {
+  final Command command;
+
   /// The transaction’s amount.
   /// Each currency has predefined allowed decimal points that should be taken into consideration when sending the amount.
   ///
@@ -57,6 +61,7 @@ class FortRequest {
   final String? phoneNumber;
 
   const FortRequest({
+    required this.command,
     required this.amount,
     required this.customerName,
     required this.customerEmail,
@@ -73,6 +78,7 @@ class FortRequest {
   });
 
   FortRequest copyWith({
+    Command? command,
     num? amount,
     String? customerName,
     String? customerEmail,
@@ -88,6 +94,7 @@ class FortRequest {
     String? phoneNumber,
   }) {
     return FortRequest(
+      command: command ?? this.command,
       amount: amount ?? this.amount,
       customerName: customerName ?? this.customerName,
       customerEmail: customerEmail ?? this.customerEmail,
@@ -106,6 +113,7 @@ class FortRequest {
 
   Map<String, dynamic> asMap() {
     return <String, dynamic>{
+      'command': command.toUpperCaseString,
       'amount': '$amount',
       'customer_name': customerName,
       'customer_email': customerEmail,


### PR DESCRIPTION
### Summary
This PR adds a `Command` enum as a required parameter in the `FortRequest` class. This change ensures that developers explicitly specify the command type (`AUTHORIZATION` or `PURCHASE`), which is then converted to a string and sent to the native iOS and Android sides. This enhancement improves the clarity and flexibility of command handling in the app.

### Related Issue
This PR addresses the feature request mentioned in #31 

### Changes Introduced
- Added `Command` Enum
  - Enum includes values: `authorization` and `purchase`.
  - Added `toUpperCaseString` getter for easy uppercase string conversion.

- Updated `FortRequest` Class
  - Made `command` a required parameter in `FortRequest` to enforce explicit command specification.
  - Enhanced logic to convert the `Command` enum to a `string` before sending it to the native sides.

### Benefits
- Ensures developers provide the `command` parameter, preventing default or unintended command types
- Supports dynamic command handling with clear type safety
- Facilitates consistent communication with native iOS and Android code

